### PR TITLE
fix benchmark grammar, I think

### DIFF
--- a/Java/examples/src/main/resources/com/yuvalshavit/antlr4/examples/benchmark/BenchGramDenting.g4
+++ b/Java/examples/src/main/resources/com/yuvalshavit/antlr4/examples/benchmark/BenchGramDenting.g4
@@ -22,7 +22,7 @@ tokens { INDENT, DEDENT }
   }
 }
 
-block: INDENT stat (NL stat)* DEDENT;
+block: INDENT stat+ DEDENT;
 
 stat: assign 
     | ifBlock
@@ -45,7 +45,7 @@ funcCall: ID '(' argsList? ')';
 
 argsList: expr (',' expr)*;
 
-assign: ID '=' expr ';';
+assign: ID '=' expr ';' NL;
 
 ifBlock: 'if' expr 'then' block elseIfBlock?;
 elseIfBlock: 'else' 'if' expr 'then' block elseBlock?;


### PR DESCRIPTION
Discovered while looking into bug #22. Before, I had a block as an
indent, and then statements separated by newlines. Instead, I think it
needs to just be a series of statements, with any one-liner statements
(of which the only is `assign` having their own newline).

This is because antlr-denter will insert a single newline before a
stretch of dedents.